### PR TITLE
Patient dash board redesign

### DIFF
--- a/MedscribeUI/src/components/FollowUpSearchModal/FollowUpSearchModalLayout.tsx
+++ b/MedscribeUI/src/components/FollowUpSearchModal/FollowUpSearchModalLayout.tsx
@@ -34,6 +34,7 @@ const FollowUpSearchModalLayout = ({
     console.log('hit');
     handleSelectedVisit(item);
     setSelectedVisitID(item.id);
+    console.log('this is item', item);
     setPatientName(item.patientName);
     setIsModalOpen(false); // Close modal after selection
   };

--- a/MedscribeUI/src/components/FollowUpSearchModal/SearchInput/SearchInput.tsx
+++ b/MedscribeUI/src/components/FollowUpSearchModal/SearchInput/SearchInput.tsx
@@ -13,14 +13,25 @@ const SearchInput: React.FC<SearchInputProps> = ({ query, setQuery }) => {
   return (
     <div className=" h-[60px] w-full px-4 py-2 bg-white border border-gray-300 rounded-t-lg shadow-sm hover:border-gray-400">
       <div className="flex items-center h-full">
-        <svg className="w-6 h-6 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
+        <svg
+          className="w-6 h-6 text-gray-400"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
+          />
         </svg>
         <input
           type="text"
           value={query}
           onChange={handleSearchChange}
-          placeholder="Search follow-ups..."
+          placeholder="Search Previous Visits"
           className="ml-2 w-full h-full bg-transparent border-none outline-none text-gray-700 placeholder-gray-500 text-lg"
         />
       </div>

--- a/MedscribeUI/src/components/FollowUpSearchModal/SearchResults/SearchResults.tsx
+++ b/MedscribeUI/src/components/FollowUpSearchModal/SearchResults/SearchResults.tsx
@@ -1,3 +1,5 @@
+import { IconX } from '@tabler/icons-react';
+
 export interface SearchResultItem {
   id: string;
   patientName: string;
@@ -29,6 +31,10 @@ const SearchResults: React.FC<SearchResultsProps> = ({
     return duration > 1 ? durationToString : '< 1 min';
   };
 
+  const handleUnselectVisit = () => {
+    onSelectItem({} as SearchResultItem);
+  };
+
   return (
     <div className="h-[400px] overflow-y-auto border border-gray-200 rounded-b-lg">
       {filteredResults.length > 0 ? (
@@ -36,8 +42,8 @@ const SearchResults: React.FC<SearchResultsProps> = ({
           {filteredResults.map(item => (
             <li
               key={item.id}
-              className={`px-4 py-3 cursor-pointer hover:bg-gray-50 transition-colors ${
-                isSelected(item.id) ? 'bg-blue-50' : ''
+              className={`px-4 py-3 cursor-pointer hover:bg-[#e8f1ff] transition-colors ${
+                isSelected(item.id) ? 'bg-blue-100' : ''
               }`}
               onClick={() => {
                 onSelectItem(item);
@@ -58,6 +64,17 @@ const SearchResults: React.FC<SearchResultsProps> = ({
                     </div>
                   )}
                 </div>
+                {isSelected(item.id) && (
+                  <IconX
+                    // Modify the onClick handler for the icon
+                    onClick={event => {
+                      event.stopPropagation();
+                      console.log('IconX onClick triggered for item:', item.id); // For debugging
+                      handleUnselectVisit();
+                    }}
+                    className="text-red-500 hover:text-red-700 transition-colors cursor-pointer" // Added cursor-pointer here too
+                  />
+                )}
               </div>
             </li>
           ))}

--- a/MedscribeUI/src/components/FollowUpSearchModal/SearchResults/SearchResults.tsx
+++ b/MedscribeUI/src/components/FollowUpSearchModal/SearchResults/SearchResults.tsx
@@ -30,7 +30,7 @@ const SearchResults: React.FC<SearchResultsProps> = ({
   };
 
   return (
-    <div className="h-[300px] overflow-y-auto border border-gray-200 rounded-b-lg">
+    <div className="h-[400px] overflow-y-auto border border-gray-200 rounded-b-lg">
       {filteredResults.length > 0 ? (
         <ul className="divide-y divide-gray-200">
           {filteredResults.map(item => (

--- a/MedscribeUI/src/components/FollowUpSearchModal/derivedAtoms.ts
+++ b/MedscribeUI/src/components/FollowUpSearchModal/derivedAtoms.ts
@@ -1,18 +1,24 @@
 import { atom } from 'jotai';
-import { patientsAtom } from '../../states/patientsAtom';
+import {
+  currentlySelectedPatientAtom,
+  patientsAtom,
+} from '../../states/patientsAtom';
 import { format } from 'date-fns';
 import { Report } from '../../states/patientsAtom';
 import { SearchResultItem } from './SearchResults/SearchResults';
 
 export const searchVisitsAtom = atom<SearchResultItem[]>(get => {
   const allVisits = get(patientsAtom);
-  return allVisits.map((visit: Report) => ({
-    id: visit.id,
-    patientName: visit.name,
-    dateOfRecording: format(new Date(visit.timestamp), 'MM/dd/yy'),
-    summary: visit.summary.data,
-    condensedSummary: visit.summary.data,
-    timeOfRecording: format(new Date(visit.timestamp), 'h:mm a'),
-    durationOfRecording: visit.duration,
-  }));
+  const currentlySelectedReport = get(currentlySelectedPatientAtom);
+  return allVisits
+    .filter(visit => visit.id !== currentlySelectedReport)
+    .map((visit: Report) => ({
+      id: visit.id,
+      patientName: visit.name,
+      dateOfRecording: format(new Date(visit.timestamp), 'MM/dd/yy'),
+      summary: visit.summary.data,
+      condensedSummary: visit.summary.data,
+      timeOfRecording: format(new Date(visit.timestamp), 'h:mm a'),
+      durationOfRecording: visit.duration,
+    }));
 });

--- a/MedscribeUI/src/components/NoteControls/derivedAtoms.ts
+++ b/MedscribeUI/src/components/NoteControls/derivedAtoms.ts
@@ -12,18 +12,22 @@ export const NoteControlsAtom = atom(get => {
       pronouns: patient.pronouns,
       visitType: patient.isFollowUp,
       patientOrClient: patient.patientOrClient,
+      visitContext: patient.visitContext,
     };
   }
   return {
     pronouns: '',
     visitType: false,
     patientOrClient: '',
+    visitContext: '',
   };
 });
 
 export interface noteControlEditsProps {
   id: string;
-  changes: Partial<Pick<Report, 'patientOrClient' | 'pronouns' | 'isFollowUp'>>;
+  changes: Partial<
+    Pick<Report, 'patientOrClient' | 'pronouns' | 'isFollowUp' | 'visitContext'>
+  >;
 }
 
 export const editPatientVisitAtom = atom(

--- a/MedscribeUI/src/components/NoteControls/noteControlsLayout.tsx
+++ b/MedscribeUI/src/components/NoteControls/noteControlsLayout.tsx
@@ -163,9 +163,7 @@ function NoteControlsLayout() {
     editPatientVisit[1](changes);
   };
 
-  const handleFollowUpVisitSelect = (visitContent: SearchResultItem) => {
-    
-  };
+  const handleFollowUpVisitSelect = (visitContent: SearchResultItem) => {};
 
   return (
     <div className="relative">

--- a/MedscribeUI/src/components/NoteControls/noteControlsLayout.tsx
+++ b/MedscribeUI/src/components/NoteControls/noteControlsLayout.tsx
@@ -43,6 +43,9 @@ function NoteControlsLayout() {
   const [selectedVisitType, setSelectedVisitType] = useState(
     noteControls.visitType,
   );
+  const [selectedVisitContext, setSelectedVisitContext] = useState(
+    noteControls.visitContext,
+  );
   const [changes, setChanges] = useState<noteControlEditsProps>({
     id: currentlySelectedPatient,
     changes: {},
@@ -76,7 +79,8 @@ function NoteControlsLayout() {
   const isDirty =
     selectedVisitType !== noteControls.visitType ||
     selectedPronoun !== noteControls.pronouns ||
-    selectedPatientClient !== noteControls.patientOrClient;
+    selectedPatientClient !== noteControls.patientOrClient ||
+    selectedVisitContext !== noteControls.visitContext;
 
   const handleVisitTypeSelect = (value: boolean) => {
     if (value !== noteControls.visitType) {
@@ -121,6 +125,17 @@ function NoteControlsLayout() {
     }
   };
 
+  const handleVisitContextSelect = (visitContext: SearchResultItem) => {
+    setSelectedVisitContext(visitContext.summary);
+    setChanges(prevChanges => ({
+      ...prevChanges,
+      changes: {
+        ...prevChanges.changes,
+        visitContext: visitContext.summary,
+      },
+    }));
+  };
+
   const handleRegenerate = () => {
     const updates: Updates[] = [];
     //Todo: send changes upstream to endPoint
@@ -158,12 +173,12 @@ function NoteControlsLayout() {
       assessmentAndPlanContent: contentData.assessmentAndPlan,
       patientInstructionsContent: contentData.patientInstructions,
       summaryContent: contentData.summary,
+      lastVisitID: currentlySelectedPatient,
+      visitContext: changes.changes.visitContext,
     });
 
     editPatientVisit[1](changes);
   };
-
-  const handleFollowUpVisitSelect = (visitContent: SearchResultItem) => {};
 
   return (
     <div className="relative">
@@ -173,10 +188,13 @@ function NoteControlsLayout() {
         overlayProps={{ radius: 'sm', blur: 2 }}
         loaderProps={{ color: 'blue', type: 'bars' }}
       />
-      <span className="block mb-2">Visit Type</span>
+      <span className="block mb-2">Link Prior Visit</span>
       <FollowUpSearchModalLayout
-        handleSelectedVisit={handleFollowUpVisitSelect}
+        handleSelectedVisit={handleVisitContextSelect}
       />
+      <hr className="my-4" />
+
+      <span className="block mb-2">Visit Type</span>
       <Select
         defaultValue={''}
         data={[NewVisit, FollowUp]}

--- a/MedscribeUI/src/components/PateintReception/derivedAtoms.ts
+++ b/MedscribeUI/src/components/PateintReception/derivedAtoms.ts
@@ -74,6 +74,8 @@ export const createReportAtom = atom(
       finishedGenerating: false,
       transcript: '',
       readStatus: false,
+      lastVisitID: '',
+      visitContext: '',
     };
     set(patientsAtom, [newReport, ...reports]);
   },

--- a/MedscribeUI/src/states/patientsAtom.ts
+++ b/MedscribeUI/src/states/patientsAtom.ts
@@ -24,7 +24,7 @@ export interface Report {
   finishedGenerating: boolean;
   transcript: string;
   readStatus: boolean;
-  lastVisit: string;
+  lastVisitID: string;
   visitContext: string;
 }
 //TODO: remove when apis are built
@@ -63,7 +63,7 @@ const reports: Report[] = [
     transcript: 'Transcript of visit 1',
     readStatus: true,
     finishedGenerating: true,
-    lastVisit: '',
+    lastVisitID: '',
     visitContext: '',
   },
   {
@@ -100,7 +100,7 @@ const reports: Report[] = [
     transcript: 'Transcript of visit 2',
     readStatus: true,
     finishedGenerating: true,
-    lastVisit: '',
+    lastVisitID: '',
     visitContext: '',
   },
   {
@@ -137,7 +137,7 @@ const reports: Report[] = [
     transcript: 'Transcript of visit 3',
     readStatus: true,
     finishedGenerating: true,
-    lastVisit: '',
+    lastVisitID: '',
     visitContext: '',
   },
   {
@@ -174,7 +174,7 @@ const reports: Report[] = [
     transcript: 'Transcript of visit 4',
     readStatus: true,
     finishedGenerating: true,
-    lastVisit: '',
+    lastVisitID: '',
     visitContext: '',
   },
 ];

--- a/MedscribeUI/src/states/patientsAtom.ts
+++ b/MedscribeUI/src/states/patientsAtom.ts
@@ -27,7 +27,6 @@ export interface Report {
   lastVisit: string;
   visitContext: string;
 }
-
 //TODO: remove when apis are built
 const reports: Report[] = [
   {
@@ -41,27 +40,22 @@ const reports: Report[] = [
     patientOrClient: Patient,
     subjective: {
       data: 'Patient presented with mild headache.',
-
       loading: false,
     },
     objective: {
       data: 'Blood pressure 120/80, no fever.',
-
       loading: false,
     },
     assessmentAndPlan: {
       data: 'Likely tension headache.',
-
       loading: false,
     },
     patientInstructions: {
       data: 'Recommend rest and hydration.',
-
       loading: false,
     },
     summary: {
       data: 'Routine follow-up recommended.',
-
       loading: false,
     },
     sessionSummary: 'Session summary 1',
@@ -69,6 +63,8 @@ const reports: Report[] = [
     transcript: 'Transcript of visit 1',
     readStatus: true,
     finishedGenerating: true,
+    lastVisit: '',
+    visitContext: '',
   },
   {
     id: 'report2',
@@ -81,7 +77,6 @@ const reports: Report[] = [
     patientOrClient: Patient,
     subjective: {
       data: 'Patient reported chronic back pain.',
-
       loading: false,
     },
     objective: {
@@ -90,7 +85,6 @@ const reports: Report[] = [
     },
     assessmentAndPlan: {
       data: 'Chronic lower back pain, further evaluation needed.',
-
       loading: false,
     },
     patientInstructions: {
@@ -106,6 +100,8 @@ const reports: Report[] = [
     transcript: 'Transcript of visit 2',
     readStatus: true,
     finishedGenerating: true,
+    lastVisit: '',
+    visitContext: '',
   },
   {
     id: 'report3',
@@ -113,32 +109,27 @@ const reports: Report[] = [
     name: 'Cockroach',
     timestamp: '2024-07-27T09:00:00Z',
     duration: 200000,
-    pronouns: They, // Using imported constant
+    pronouns: They,
     isFollowUp: false,
-    patientOrClient: Client, // Using imported constant
+    patientOrClient: Client,
     subjective: {
       data: 'Patient presented with anxiety.',
-
       loading: false,
     },
     objective: {
       data: 'Restlessness observed.',
-
       loading: false,
     },
     assessmentAndPlan: {
       data: 'Anxiety disorder.',
-
       loading: false,
     },
     patientInstructions: {
       data: 'Prescribed medication and therapy.',
-
       loading: false,
     },
     summary: {
       data: 'Follow-up appointment in two weeks.',
-
       loading: false,
     },
     sessionSummary: 'Session summary 3',
@@ -146,6 +137,8 @@ const reports: Report[] = [
     transcript: 'Transcript of visit 3',
     readStatus: true,
     finishedGenerating: true,
+    lastVisit: '',
+    visitContext: '',
   },
   {
     id: 'report4',
@@ -153,32 +146,27 @@ const reports: Report[] = [
     name: 'Satya',
     timestamp: '2024-07-27T09:00:00Z',
     duration: 200000,
-    pronouns: He, // Using imported constant
+    pronouns: He,
     isFollowUp: false,
-    patientOrClient: Patient, // Using imported constant
+    patientOrClient: Patient,
     subjective: {
       data: 'Patient presented with anxiety.',
-
       loading: false,
     },
     objective: {
       data: 'Restlessness observed.',
-
       loading: false,
     },
     assessmentAndPlan: {
       data: 'Anxiety disorder.',
-
       loading: false,
     },
     patientInstructions: {
       data: 'Prescribed medication and therapy.',
-
       loading: false,
     },
     summary: {
       data: 'Follow-up appointment in two weeks.',
-
       loading: false,
     },
     sessionSummary: 'Session summary 4',
@@ -186,6 +174,8 @@ const reports: Report[] = [
     transcript: 'Transcript of visit 4',
     readStatus: true,
     finishedGenerating: true,
+    lastVisit: '',
+    visitContext: '',
   },
 ];
 

--- a/cmd/api/api.go
+++ b/cmd/api/api.go
@@ -9,7 +9,6 @@ import (
 	inferenceService "Medscribe/inference/service"
 	inferencestore "Medscribe/inference/store"
 	"Medscribe/reports"
-	"Medscribe/transcription/azure"
 	"Medscribe/user"
 	"context"
 	"fmt"
@@ -25,7 +24,73 @@ import (
 
 type mockTranscriber struct{}
 
-const sample1 = ``
+const sample1 = `Good.
+Hi, Miss Joanne.
+How are you?
+I'm okay.
+Thank you.
+That's good.
+Happy new month.
+Happy new month to you, too.
+Okay.
+No problem.
+I've been taking it easy on myself.
+That's good.
+Awesome.
+Yeah.
+Okay.
+Okay.
+I've been doing walking, making walk, you know, that too.
+I've been doing that around the building, you know, so my fears could go away.
+I've been doing that.
+Okay.
+That's good.
+I love that.
+We got little Chloe here with me.
+Oh, really?
+Yeah, little dog.
+She's so cute.
+How old is she again?
+She's gonna be two.
+Wow.
+Okay, that's good.
+That's good, that's awesome.
+Yeah, she don't shed, she don't, she's good, she's good.
+Okay, all right, that's awesome.
+So no panic attacks, no depressive episodes?
+Not this month, no.
+Okay, all right, awesome.
+How about your mood, your mood okay?
+You know, my moods always go up and down.
+That's something normal, I think.
+Us women, we go through that, you know?
+Of course, that's we women, always going through that.
+Yeah, like we want to get the satisfaction that at one point we were getting and we're not getting it today.
+We gotta give it to ourselves.
+Yes.
+Yes.
+Okay.
+All right.
+So how about your medication?
+Everything?
+Everything's working.
+Everything is working.
+Okay.
+All right.
+I will send you all of your medication to your pharmacy, the gabapentin, lorazepam, you know, hydralazine, mirtazapine and duloxetine.
+Okay.
+And your Suboxone.
+Okay.
+Thank you very much.
+All right.
+Yes, I will see you next month on, um, let me tell you, um, that would be one, 2, 3 July, May 3rd at 9 a. m.
+Yeah, we're good.
+Alright, see you, okay?
+Nice talking with you, honey.
+Alright.
+Have a nice weekend.
+And you too, bye.
+Okay.`
 
 func (m *mockTranscriber) Transcribe(ctx context.Context, audio []byte) (string, error) {
 	return sample1, nil
@@ -87,15 +152,15 @@ func main() {
 		cfg.OpenAIAPIKey,
 	)
 
-	transcriber := azure.NewAzureTranscriber(
-		cfg.OpenAISpeechURL,
-		cfg.OpenAIAPIKey,
-	)
+	// transcriber := azure.NewAzureTranscriber(
+	// 	cfg.OpenAISpeechURL,
+	// 	cfg.OpenAIAPIKey,
+	// )
 
 	inferenceService := inferenceService.NewInferenceService(
 		reportsStore,
-		// &mockTranscriber{},
-		transcriber,
+		&mockTranscriber{},
+		// transcriber,
 		inferenceStore,
 		userStore,
 	)

--- a/inference/service/prompts.go
+++ b/inference/service/prompts.go
@@ -639,7 +639,7 @@ func GenerateReportContentPrompt(transcribedAudio, soapSection, style, providerN
         providerName,
         soapSection,
     )
-
+    
     if context != "" {
         prompt += fmt.Sprintf(`**IMPORTANT CONTEXT FROM PREVIOUS VISIT:** %s\n\n`, context)
         prompt += fmt.Sprintf(`Use this information as an aid and reference when generating the %s section.\n\n`, soapSection)


### PR DESCRIPTION
Key Changes:

1. Feature Implementation (Follow-Up Context):
* UI Integration: Integrated FollowUpSearchModalLayout into NoteControlsLayout under "Link Prior Visit", allowing users to select a prior visit. (NoteControls/noteControlsLayout.tsx)
* State Management:
* Selecting a visit in the modal now populates a new visitContext field. (NoteControls/noteControlsLayout.tsx)
* Updated the core Report interface and related atoms (patientsAtom.ts, PateintReception/derivedAtoms.ts, NoteControls/derivedAtoms.ts) to include and handle the visitContext string.
* Backend Prompting: Modified the backend prompt generation (inference/service/prompts.go) to include the visitContext (labeled as "IMPORTANT CONTEXT FROM PREVIOUS VISIT") when regenerating report sections, providing the AI with historical context.

2. FollowUpSearchModal Improvements:
* Filtering: Updated searchVisitsAtom logic to filter out the currently selected patient/visit from the list of searchable previous visits. (FollowUpSearchModal/derivedAtoms.ts)
* UI Tweaks:
* Increased the height of the search results area for better visibility. (SearchResults/SearchResults.tsx)
* Updated the placeholder text in the search input for clarity. (SearchInput/SearchInput.tsx)
* Cleaned up minor SVG duplication in search input. (SearchInput/SearchInput.tsx)

3. Development/Testing Changes:
* Temporarily switched the backend API service (cmd/api/api.go) to use a mockTranscriber with static sample text instead of the live Azure transcription service, likely for easier local testing.

Potential Issues / Discussion Points:
As noted previously, initial observations suggest some regenerated report content might appear malformed. This is related to how the visitContext interacts with the existing prompting strategy in prompts.go. I'm going to work on this later