### PR TITLE
Profile routing

### DIFF
--- a/MedscribeUI/src/App.tsx
+++ b/MedscribeUI/src/App.tsx
@@ -12,8 +12,9 @@ import { checkAuth } from './api/checkAuth';
 import AuthScreen from './pages/Auth/authScreen';
 import FallbackScreen from './pages/Fallback/fallbackScreen';
 import LandingScreen from './pages/Landing/landingScreen';
+import ProfileScreen from './pages/Profile/profileScreen';
 import { useEffect, useState } from 'react';
-import { BrowserRouter, Routes, Route } from 'react-router-dom';
+import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
 
 function App() {
   const [timerActive, setTimerActive] = useState(true);
@@ -81,10 +82,18 @@ function App() {
   const renderAuthComponent = () => {
     if (isPending || isIdle || timerActive) {
       return <FallbackScreen />;
-    } else if (isSuccess || isAuthenticated) {
+    } else if (isSuccess || isAuthenticated || true) { // TODO: Remove this
       return <HomeScreen />;
     } else {
       return <LandingScreen />;
+    }
+  };
+
+  const renderProfileComponent = () => {
+    if (isSuccess || isAuthenticated || true) { // TODO: Remove this
+      return <ProfileScreen />;
+    } else {
+      return <Navigate to="/" />;
     }
   };
 
@@ -94,6 +103,7 @@ function App() {
         <Route path="/" element={renderAuthComponent()} />
         <Route path="/SignUp" element={<AuthScreen isSignUpRoute={true} />} />
         <Route path="/SignIn" element={<AuthScreen isSignUpRoute={false} />} />
+        <Route path="/Profile" element={renderProfileComponent()} />
       </Routes>
     </BrowserRouter>
   );

--- a/MedscribeUI/src/App.tsx
+++ b/MedscribeUI/src/App.tsx
@@ -90,7 +90,7 @@ function App() {
   };
 
   const renderProfileComponent = () => {
-    if (isSuccess || isAuthenticated) {
+    if (isAuthenticated) {
       return <ProfileScreen />;
     } else {
       return <Navigate to="/" />;

--- a/MedscribeUI/src/App.tsx
+++ b/MedscribeUI/src/App.tsx
@@ -82,7 +82,7 @@ function App() {
   const renderAuthComponent = () => {
     if (isPending || isIdle || timerActive) {
       return <FallbackScreen />;
-    } else if (isSuccess || isAuthenticated || true) { // TODO: Remove this
+    } else if (isSuccess || isAuthenticated) {
       return <HomeScreen />;
     } else {
       return <LandingScreen />;
@@ -90,7 +90,7 @@ function App() {
   };
 
   const renderProfileComponent = () => {
-    if (isSuccess || isAuthenticated || true) { // TODO: Remove this
+    if (isSuccess || isAuthenticated) {
       return <ProfileScreen />;
     } else {
       return <Navigate to="/" />;

--- a/MedscribeUI/src/components/Header/header.tsx
+++ b/MedscribeUI/src/components/Header/header.tsx
@@ -1,9 +1,37 @@
+import { useNavigate } from "react-router-dom";
+import { Button } from "@mantine/core";
+
 export const Header = () => {
+  const navigate = useNavigate();
   return (
     <div className="flex items-center bg-blue-500 h-10 px-4">
-      <h1 className="text-white text-lg font-semibold leading-none">
+      <button
+        className="text-white text-lg font-semibold leading-none hover:opacity-80 transition-opacity"
+        onClick={() => navigate('/')}
+      >
         Medscribe
-      </h1>
+      </button>
+      <div className="flex-1"></div>
+      <Button
+        variant="subtle"
+        onClick={() => navigate('/profile')}
+        className="text-white rounded-full w-8 h-8 p-0 flex items-center justify-center hover:bg-blue-600 transition-colors"
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          className="h-5 w-5"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z"
+          />
+        </svg>
+      </Button>
     </div>
   );
 };

--- a/MedscribeUI/src/components/Profile/ProfileSidebar.tsx
+++ b/MedscribeUI/src/components/Profile/ProfileSidebar.tsx
@@ -1,0 +1,61 @@
+import { useNavigate } from 'react-router-dom';
+import { IconArrowBackUp, IconLogout2} from '@tabler/icons-react';
+
+
+interface ProfileSidebarProps {
+  onNavChange: (tab: 'settings' | 'affiliates' | 'subscriptions') => void;
+  activeTab: 'settings' | 'affiliates' | 'subscriptions';
+}
+
+const ProfileSidebar = ({ onNavChange, activeTab }: ProfileSidebarProps) => {
+  const navigate = useNavigate();
+  const navItems = [
+    { id: 'settings', label: 'Settings' },
+    { id: 'affiliates', label: 'Affiliates' },
+    { id: 'subscriptions', label: 'Subscriptions' },
+  ];
+
+  const handleLogout = () => {
+    // Implement logout functionality here
+    // For example, clear local storage, reset auth state, etc.
+    navigate('/login');
+  };
+
+  return (
+    <div className="w-64 border-r h-full p-4 flex flex-col">
+      <button onClick={() => navigate('/')} className="flex items-center text-gray-600 hover:text-gray-900 mb-6">
+        <IconArrowBackUp className="h-5 w-5 mr-2" />
+        Back
+      </button>
+      <nav>
+        <ul className="space-y-2">
+          {navItems.map((item) => (
+            <li key={item.id}>
+              <button
+                onClick={() => onNavChange(item.id as any)}
+                className={`w-full text-left px-4 py-2 rounded-md transition ${
+                  activeTab === item.id
+                    ? 'bg-blue-100 text-blue-700 font-medium'
+                    : 'hover:bg-gray-100'
+                }`}
+              >
+                {item.label}
+              </button>
+            </li>
+          ))}
+        </ul>
+      </nav>
+      <div className="mt-auto pt-4">
+        <button
+          onClick={handleLogout}
+          className="w-full flex items-center px-1 py-2 text-red-600 hover:text-red-800 hover:bg-red-50 rounded-md transition"
+        >
+          <IconLogout2 className="h-5 w-5 mr-2" />
+          Logout
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default ProfileSidebar; 

--- a/MedscribeUI/src/components/Profile/ProfileSidebar.tsx
+++ b/MedscribeUI/src/components/Profile/ProfileSidebar.tsx
@@ -1,15 +1,16 @@
 import { useNavigate } from 'react-router-dom';
 import { IconArrowBackUp, IconLogout2} from '@tabler/icons-react';
 
+export type ProfileTabType = 'settings' | 'affiliates' | 'subscriptions';
 
 interface ProfileSidebarProps {
-  onNavChange: (tab: 'settings' | 'affiliates' | 'subscriptions') => void;
-  activeTab: 'settings' | 'affiliates' | 'subscriptions';
+  onNavChange: (tab: ProfileTabType) => void;
+  activeTab: ProfileTabType;
 }
 
 const ProfileSidebar = ({ onNavChange, activeTab }: ProfileSidebarProps) => {
   const navigate = useNavigate();
-  const navItems = [
+  const navItems: Array<{ id: ProfileTabType; label: string }> = [
     { id: 'settings', label: 'Settings' },
     { id: 'affiliates', label: 'Affiliates' },
     { id: 'subscriptions', label: 'Subscriptions' },
@@ -32,7 +33,7 @@ const ProfileSidebar = ({ onNavChange, activeTab }: ProfileSidebarProps) => {
           {navItems.map((item) => (
             <li key={item.id}>
               <button
-                onClick={() => onNavChange(item.id as any)}
+                onClick={() => onNavChange(item.id)}
                 className={`w-full text-left px-4 py-2 rounded-md transition ${
                   activeTab === item.id
                     ? 'bg-blue-100 text-blue-700 font-medium'

--- a/MedscribeUI/src/components/Profile/profileAffiliates.tsx
+++ b/MedscribeUI/src/components/Profile/profileAffiliates.tsx
@@ -1,0 +1,10 @@
+
+const ProfileAffiliates = () => {
+    return (
+      <div className="flex justify-center items-center h-full">
+        <h1 className="text-2xl font-bold">Profile Affiliates</h1>
+      </div>
+    );
+  };
+  
+  export default ProfileAffiliates;

--- a/MedscribeUI/src/components/Profile/profileSettings.tsx
+++ b/MedscribeUI/src/components/Profile/profileSettings.tsx
@@ -1,0 +1,11 @@
+
+
+const ProfileSettings = () => {
+    return (
+      <div className="flex justify-center items-center h-full">
+        <h1 className="text-2xl font-bold">Profile Settings</h1>
+      </div>
+    );
+  };
+  
+  export default ProfileSettings;

--- a/MedscribeUI/src/components/Profile/profileSubscriptions.tsx
+++ b/MedscribeUI/src/components/Profile/profileSubscriptions.tsx
@@ -1,0 +1,10 @@
+
+const ProfileSubscriptions = () => {
+    return (
+      <div className="flex justify-center items-center h-full">
+        <h1 className="text-2xl font-bold">Profile Subscriptions</h1>
+      </div>
+    );
+  };
+  
+export default ProfileSubscriptions;

--- a/MedscribeUI/src/pages/Profile/profileScreen.stories.tsx
+++ b/MedscribeUI/src/pages/Profile/profileScreen.stories.tsx
@@ -1,0 +1,32 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import ProfileScreen from './profileScreen';
+import { MantineProvider } from '@mantine/core';
+import '@mantine/core/styles.css';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+const ProfileScreenWrapper = () => {
+  const queryClient = new QueryClient();
+
+  return (
+    <div>
+      <QueryClientProvider client={queryClient}>
+        <MantineProvider>
+          <ProfileScreen />
+        </MantineProvider>
+      </QueryClientProvider>
+    </div>
+  );
+};
+
+const meta: Meta<typeof ProfileScreenWrapper> = {
+  title: 'ProfileScreen',
+  component: ProfileScreenWrapper,
+  parameters: {
+    layout: 'fullscreen',
+  }
+};
+export default meta;
+
+type Story = StoryObj<typeof ProfileScreenWrapper>;
+
+export const Wrapped: Story = {};

--- a/MedscribeUI/src/pages/Profile/profileScreen.tsx
+++ b/MedscribeUI/src/pages/Profile/profileScreen.tsx
@@ -3,12 +3,13 @@ import ProfileSettings from '../../components/Profile/profileSettings';
 import ProfileAffiliates from '../../components/Profile/profileAffiliates';
 import ProfileSubscriptions from '../../components/Profile/profileSubscriptions';
 import ProfileSidebar from '../../components/Profile/ProfileSidebar';
+import { ProfileTabType } from '../../components/Profile/ProfileSidebar';
 import { Header } from '../../components/Header/header';
 
 const ProfileScreen = () => {
-  const [activeTab, setActiveTab] = useState<'settings' | 'affiliates' | 'subscriptions'>('settings');
+  const [activeTab, setActiveTab] = useState<ProfileTabType>('settings');
 
-  const renderActiveComponent = () => {
+  const sidebarContentDisplay = () => {
     switch (activeTab) {
       case 'settings':
         return <ProfileSettings />;
@@ -29,7 +30,7 @@ const ProfileScreen = () => {
       <div className="flex flex-row flex-1">
         <ProfileSidebar onNavChange={setActiveTab} activeTab={activeTab} />
         <div className="flex-1 p-6 overflow-auto">
-          {renderActiveComponent()}
+          {sidebarContentDisplay()}
         </div>
       </div>
     </div>

--- a/MedscribeUI/src/pages/Profile/profileScreen.tsx
+++ b/MedscribeUI/src/pages/Profile/profileScreen.tsx
@@ -1,0 +1,39 @@
+import { useState } from 'react';
+import ProfileSettings from '../../components/Profile/profileSettings';
+import ProfileAffiliates from '../../components/Profile/profileAffiliates';
+import ProfileSubscriptions from '../../components/Profile/profileSubscriptions';
+import ProfileSidebar from '../../components/Profile/ProfileSidebar';
+import { Header } from '../../components/Header/header';
+
+const ProfileScreen = () => {
+  const [activeTab, setActiveTab] = useState<'settings' | 'affiliates' | 'subscriptions'>('settings');
+
+  const renderActiveComponent = () => {
+    switch (activeTab) {
+      case 'settings':
+        return <ProfileSettings />;
+      case 'affiliates':
+        return <ProfileAffiliates />;
+      case 'subscriptions':
+        return <ProfileSubscriptions />;
+      default:
+        return <ProfileSettings />;
+    }
+  };
+
+  return (
+    <div className="flex flex-col h-screen w-full">
+      <div>
+        <Header />
+      </div>
+      <div className="flex flex-row flex-1">
+        <ProfileSidebar onNavChange={setActiveTab} activeTab={activeTab} />
+        <div className="flex-1 p-6 overflow-auto">
+          {renderActiveComponent()}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ProfileScreen;


### PR DESCRIPTION
Added Profile folder with 3 main pages and logic for sidebar.

Sidebar includes back button and logout button (no logout functionality yet)

Edited header to include a profile icon which will route to /profile

Change Medscribe Logo so that on press it routes to /

Fixed routing to the Settings page in App.tsx

![image](https://github.com/user-attachments/assets/8dcc45f4-8395-4f68-8755-96dbbe61462c)
